### PR TITLE
Set up new default definitions for Nginx default server config

### DIFF
--- a/config/nginx/sites-available/default-example
+++ b/config/nginx/sites-available/default-example
@@ -6,13 +6,17 @@ server {
 
     autoindex on;
 
-    access_log /var/log/nginx/access.log;
-    error_log /var/log/nginx/error.log;
+    # this is the internal Docker DNS, cache only for 30s
+    resolver 127.0.0.11 valid=30s;
 
     location ~ \.php$ {
+
+        # using variables to set up hosts avoid Nginx startup errors when trying to access a host that is not running yet
+        set $upstream php-7.2:9000;
+
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass php-7.1:9000;
+        fastcgi_pass $upstream;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
@@ -30,22 +34,24 @@ server {
 # server {
 #     listen  443;
 #     listen  [::]:443;
-# 
+
 #     root /app;
 #     server_name domain.name;
 #     index index.php index.html;
-# 
+
 #     ssl    on;
 #     ssl_certificate     /etc/ssl/certs/nginx-selfsigned.crt;
 #     ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;
-# 
-#     access_log /var/log/nginx/access.log;
-#     error_log /var/log/nginx/error.log;
-# 
+
+#     resolver 127.0.0.11 valid=30s;
+
 #     location ~ \.php$ {
+
+#         set $upstream php-7.2:9000;
+
 #         try_files $uri =404;
 #         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-#         fastcgi_pass php-7.1:9000;
+#         fastcgi_pass $upstream;
 #         fastcgi_index index.php;
 #         include fastcgi_params;
 #         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;


### PR DESCRIPTION
- Removing log paths because they are already defined in http global scope in nginx.conf file.

- Using variables to set up hosts and avoid Nginx startup errors when trying to access a host that is not running yet and when this host become available everything will work fine without restart Nginx.

- Using internal Docker DNS as resolver definition.